### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "main": "./lib/date.js",
   "version": "1.0.0",
   "description": "Insert the current date & time. See the readme for format options.",
-  "activationEvents": [
-    "date:date",
-    "date:time",
-    "date:datetime"
-  ],
+  "activationCommands": {
+    "atom-text-editor": ["date:date", "date:time", "date:datetime"]
+  },
   "repository": "https://github.com/dannyfritz/atom-date",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Fixes #3.

The "atom-text-editor" is used since we don't need the plugin to be loaded in the workspace screen.