### PR TITLE
Add missing '&' for menu label

### DIFF
--- a/menus/date.cson
+++ b/menus/date.cson
@@ -7,7 +7,7 @@
       'submenu': [
         { 'label': 'Insert Date', 'command': 'date:date' }
         { 'label': 'Insert Time', 'command': 'date:time' }
-        { 'label': 'Insert Date & Time', 'command': 'date:datetime' }
+        { 'label': 'Insert Date && Time', 'command': 'date:datetime' }
       ]
     ]
   }


### PR DESCRIPTION
The menu item should have read "Insert Date & Time" but instead read "Insert Date  Time".

In order to display an '&' the label must contain two ampersands. As in '&&'.

This is the case for 'Date & Time' which is defined above.