### PR TITLE
Add configuration for prefix and suffix

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -50,6 +50,16 @@ module.exports =
       default: true,
       type: "boolean",
       order: 1
+    },
+    prefix: {
+      default: "",
+      type: "string",
+      order: 2
+    },
+    suffix: {
+      default: "",
+      type: "string",
+      order: 2
     }
   }
 };
@@ -66,9 +76,12 @@ function getConfig(property)
 
 function getOutput(format)
 {
+  var output;
   if (getConfig("isLocalTimeZone")) {
-    return moment().format(format);
+    output = moment().format(format);
   } else {
-    return moment.utc().format(format);
+    output = moment.utc().format(format);
   }
+  output = getConfig("prefix") + output + getConfig("suffix");
+  return output;
 }


### PR DESCRIPTION
This code introduces a prefix and suffix configuration.

My personal use case this:

I need to add dates prefixed with "[" and suffixed with "]", like this:
[2020-09-11]
[2020-09-11 12:39]
[12:39]

"prefix" and "suffix" default to empty string "".

Tested locally.
It's my first time contributing to an atom-editor package, please let me know if anything else is needed.
Thanks!

![2020-09-11-125021-atom-date-prefix-suffix-config](https://user-images.githubusercontent.com/219397/92916842-30a4c880-f42e-11ea-89a8-919334909038.png)
